### PR TITLE
Improve error handling.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,12 @@ mod tui;
 mod twitch;
 mod utils;
 
+const CONFIG_PATH: &str = "config.toml";
+const DEFAULT_CONFIG_PATH: &str = "default-config.toml";
+
 fn main() -> Result<()> {
-    if let Ok(config_contents) = fs::read_to_string("config.toml") {
-        let config: CompleteConfig = toml::from_str(config_contents.as_str()).unwrap();
+    if let Ok(config_contents) = fs::read_to_string(CONFIG_PATH) {
+        let config: CompleteConfig = toml::from_str(config_contents.as_str())?;
 
         let app = App::default();
 
@@ -25,6 +28,12 @@ fn main() -> Result<()> {
         });
 
         tui::tui(cloned_config, app, rx).unwrap();
+    } else {
+        println!(
+            "Error: configuration not found. Please create a config file at '{}', and see '{}' for an example configuration.",
+            CONFIG_PATH,
+            DEFAULT_CONFIG_PATH,
+        );
     }
 
     Ok(())


### PR DESCRIPTION
Now, an error is printed when the config file is not found, instead of the application exiting immediately.

Any toml parsing errors are also propagated to get a nice error message instead of panicking.