### PR TITLE
Improve username colors.

### DIFF
--- a/default-config.toml
+++ b/default-config.toml
@@ -17,3 +17,6 @@ tick_delay = 30
 date_format = "%a %b %e %T %Y"
 # The longest a username can be.
 maximum_username_length = 26
+# Optional: The color palette for the username column (Default: pastel)
+# One of: pastel, vibrant, warm, cool
+palette = "vibrant"

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -1,6 +1,21 @@
 use serde::Deserialize;
 
 #[derive(Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum Palette {
+    Pastel,
+    Vibrant,
+    Warm,
+    Cool,
+}
+
+impl Default for Palette {
+    fn default() -> Self {
+        Palette::Pastel
+    }
+}
+
+#[derive(Deserialize, Clone)]
 pub struct CompleteConfig {
     /// Connecting to Twitch.
     pub twitch: TwitchConfig,
@@ -32,4 +47,7 @@ pub struct FrontendConfig {
     pub date_format: String,
     /// The maximum length of a Twitch username.
     pub maximum_username_length: u16,
+    /// The color palette
+    #[serde(default)]
+    pub palette: Palette,
 }

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -1,3 +1,4 @@
+use crate::handlers::config::Palette;
 use tui::style::{Color, Color::Rgb, Style};
 use tui::widgets::{Cell, Row};
 
@@ -19,20 +20,27 @@ impl Data {
         }
     }
 
-    pub fn hash_username(&self) -> Color {
-        let hue = self
+    pub fn hash_username(&self, palette: &Palette) -> Color {
+        let hash = self
             .author
             .as_bytes()
             .iter()
             .map(|&b| b as u32)
-            .sum::<u32>() as f64
-            % 360.;
-        let rgb = hsl_to_rgb(hue, 0.5, 0.75);
+            .sum::<u32>() as f64;
+
+        let (hue, saturation, lightness) = match palette {
+            Palette::Pastel => (hash % 360. + 1., 0.5, 0.75),
+            Palette::Vibrant => (hash % 360. + 1., 1., 0.6),
+            Palette::Warm => ((hash % 100. + 1.) * 1.2, 0.8, 0.7),
+            Palette::Cool => ((hash % 100. + 1.) * 1.2 + 180., 0.6, 0.7),
+        };
+
+        let rgb = hsl_to_rgb(hue, saturation, lightness);
 
         Rgb(rgb[0], rgb[1], rgb[2])
     }
 
-    pub fn to_row(&self) -> Row {
+    pub fn to_row(&self, palette: &Palette) -> Row {
         return if self.empty {
             Row::new(vec![
                 Cell::from("".to_string()),
@@ -43,7 +51,7 @@ impl Data {
             Row::new(vec![
                 Cell::from(self.time_sent.to_string()),
                 Cell::from(self.author.to_string())
-                    .style(Style::default().fg(self.hash_username())),
+                    .style(Style::default().fg(self.hash_username(palette))),
                 Cell::from(self.message.to_string()),
             ])
         };

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -140,8 +140,8 @@ mod tests {
     #[test]
     fn test_username_hash() {
         assert_eq!(
-            create_data().hash_username(),
-            Rgb(104 * 2, 117 * 2, 109 * 2)
+            create_data().hash_username(&Palette::Pastel),
+            Rgb(159, 223, 221)
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -81,7 +81,7 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
             let table = Table::new(
                 final_rendered_messages
                     .iter()
-                    .map(|m| m.to_row())
+                    .map(|m| m.to_row(&config.frontend.palette))
                     .collect::<Vec<Row>>(),
             )
             .header(


### PR DESCRIPTION
Username colors are now calculated from a sum of the bytes in the name % 360 used as hue, with 50% saturation and 75% lightness for a pastel palette.
![image](https://user-images.githubusercontent.com/41782385/132109767-7d1ce22e-e407-46db-a6b0-9b5def1036b8.png)