### PR TITLE
General QOL features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "tui"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861d8f3ad314ede6219bcb2ab844054b1de279ee37a9bc38e3d606f9d3fb2a71"
+checksum = "39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23"
 dependencies = [
  "bitflags",
  "cassowary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.42"
-tui = "0.15"
+tui = "0.16.0"
 termion = "1.5"
 rand = "0.8.4"
 unicode-width = "0.1.5"

--- a/default-config.toml
+++ b/default-config.toml
@@ -11,12 +11,15 @@ server = "irc.chat.twitch.tv"
 [terminal]
 # The delay in milliseconds between terminal updates.
 tick_delay = 30
+# The maximum amount of messages to be stored.
+maximum_messages = 1000
 
 [frontend]
 # The format of the date and time outputs, https://strftime.org/ has formats.
 date_format = "%a %b %e %T %Y"
 # The longest a username can be.
 maximum_username_length = 26
-# Optional: The color palette for the username column (Default: pastel)
-# One of: pastel, vibrant, warm, cool
-palette = "vibrant"
+# Which side the username should be aligned to.
+username_alignment = "right"
+# The color palette for the username column: pastel (default), vibrant, warm, cool.
+palette = "pastel"

--- a/default-config.toml
+++ b/default-config.toml
@@ -15,6 +15,8 @@ tick_delay = 30
 maximum_messages = 1000
 
 [frontend]
+# If the time and date is to be shown.
+date_shown = true
 # The format of the date and time outputs, https://strftime.org/ has formats.
 date_format = "%a %b %e %T %Y"
 # The longest a username can be.

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -45,6 +45,8 @@ pub struct TerminalConfig {
 
 #[derive(Deserialize, Clone)]
 pub struct FrontendConfig {
+    // If the time and date is to be shown.
+    pub date_shown: bool,
     /// The format of string that will show up in the terminal.
     pub date_format: String,
     /// The maximum length of a Twitch username.

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -39,6 +39,8 @@ pub struct TwitchConfig {
 pub struct TerminalConfig {
     /// The delay between updates, in milliseconds.
     pub tick_delay: u64,
+    /// The maximum amount of messages to be stored.
+    pub maximum_messages: u64,
 }
 
 #[derive(Deserialize, Clone)]
@@ -47,6 +49,8 @@ pub struct FrontendConfig {
     pub date_format: String,
     /// The maximum length of a Twitch username.
     pub maximum_username_length: u16,
+    /// Which side the username should be aligned to.
+    pub username_alignment: String,
     /// The color palette
     #[serde(default)]
     pub palette: Palette,

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -45,8 +45,7 @@ impl Data {
     pub fn to_row(&self, frontend_config: &FrontendConfig, limit: &usize) -> (u16, Row) {
         let message = textwrap::fill(self.message.as_str(), *limit);
 
-        let mut row = Row::new(vec![
-            Cell::from(self.time_sent.to_string()),
+        let mut row_vector = vec![
             Cell::from(align_text(
                 &self.author,
                 frontend_config.username_alignment.as_str(),
@@ -54,9 +53,15 @@ impl Data {
             ))
             .style(Style::default().fg(self.hash_username(&frontend_config.palette))),
             Cell::from(message.to_string()),
-        ]);
+        ];
+
+        if frontend_config.date_shown {
+            row_vector.insert(0, Cell::from(self.time_sent.to_string()));
+        }
 
         let msg_height = message.split("\n").collect::<Vec<&str>>().len() as u16;
+
+        let mut row = Row::new(row_vector);
 
         if msg_height > 1 {
             row = row.height(msg_height);

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -1,7 +1,7 @@
 use tui::style::{Color, Color::Rgb, Style};
 use tui::widgets::{Cell, Row};
 
-use crate::handlers::config::Palette;
+use crate::handlers::config::{FrontendConfig, Palette};
 
 #[derive(Debug, Clone)]
 pub struct Data {
@@ -41,13 +41,24 @@ impl Data {
         Rgb(rgb[0], rgb[1], rgb[2])
     }
 
-    pub fn to_row(&self, palette: &Palette, limit: usize) -> (u16, Row) {
+    pub fn to_row(&self, frontend_config: &FrontendConfig, limit: &usize) -> (u16, Row) {
+        let mut username = &self.author;
+        if frontend_config.username_alignment == "right" {
+            username = &format!(
+                "{}{}",
+                " ".repeat(
+                    (frontend_config.maximum_username_length - username.len() as u16) as usize
+                ),
+                username
+            );
+        }
+
         let message = textwrap::fill(self.message.as_str(), limit);
 
         let mut row = Row::new(vec![
             Cell::from(self.time_sent.to_string()),
-            Cell::from(self.author.to_string())
-                .style(Style::default().fg(self.hash_username(palette))),
+            Cell::from(username.to_string())
+                .style(Style::default().fg(self.hash_username(&frontend_config.palette))),
             Cell::from(message.to_string()),
         ]);
 

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -1,23 +1,24 @@
 use tui::style::{Color, Color::Rgb, Style};
 use tui::widgets::{Cell, Row};
 
-use crate::handlers::config::{FrontendConfig, Palette};
+use crate::{
+    handlers::config::{FrontendConfig, Palette},
+    utils::text::align_text,
+};
 
 #[derive(Debug, Clone)]
 pub struct Data {
     pub time_sent: String,
     pub author: String,
     pub message: String,
-    pub empty: bool,
 }
 
 impl Data {
-    pub fn new(time_sent: String, author: String, message: String, empty: bool) -> Self {
+    pub fn new(time_sent: String, author: String, message: String) -> Self {
         Data {
             time_sent,
             author,
             message,
-            empty,
         }
     }
 
@@ -42,23 +43,16 @@ impl Data {
     }
 
     pub fn to_row(&self, frontend_config: &FrontendConfig, limit: &usize) -> (u16, Row) {
-        let mut username = &self.author;
-        if frontend_config.username_alignment == "right" {
-            username = &format!(
-                "{}{}",
-                " ".repeat(
-                    (frontend_config.maximum_username_length - username.len() as u16) as usize
-                ),
-                username
-            );
-        }
-
-        let message = textwrap::fill(self.message.as_str(), limit);
+        let message = textwrap::fill(self.message.as_str(), *limit);
 
         let mut row = Row::new(vec![
             Cell::from(self.time_sent.to_string()),
-            Cell::from(username.to_string())
-                .style(Style::default().fg(self.hash_username(&frontend_config.palette))),
+            Cell::from(align_text(
+                &self.author,
+                frontend_config.username_alignment.as_str(),
+                &frontend_config.maximum_username_length,
+            ))
+            .style(Style::default().fg(self.hash_username(&frontend_config.palette))),
             Cell::from(message.to_string()),
         ]);
 
@@ -116,7 +110,6 @@ mod tests {
             Local::now().format("%c").to_string(),
             "human".to_string(),
             "beep boop".to_string(),
-            false,
         )
     }
 
@@ -127,14 +120,4 @@ mod tests {
             Rgb(159, 223, 221)
         );
     }
-
-    // #[test]
-    // fn test_data_message_wrapping() {
-    //     let mut some_data = create_data();
-    //     some_data.message = "asdf ".repeat(39);
-    //     assert_eq!(some_data.message.len(), 195);
-    //
-    //     let some_vec = some_data.wrap_message(157);
-    //     assert_eq!(some_vec.len(), 2);
-    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
     if let Ok(config_contents) = fs::read_to_string(CONFIG_PATH) {
         let config: CompleteConfig = toml::from_str(config_contents.as_str())?;
 
-        let app = App::default();
+        let app = App::new(config.terminal.maximum_messages as usize);
 
         let (tx, rx) = std::sync::mpsc::channel();
         let cloned_config = config.clone();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -57,7 +57,7 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
 
     loop {
         if let Ok(info) = rx.try_recv() {
-            app.messages.push(info);
+            app.messages.push_front(info);
         }
 
         terminal.draw(|f| {
@@ -79,12 +79,17 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
             // The chunk furthest to the right is the messages, that's the one we want.
             let message_chunk_width = horizontal_chunks[table_width.len() - 1].width as usize - 4;
 
+            // Making sure that messages do have a limit and don't eat up all the RAM.
+            &app.messages
+                .truncate(config.terminal.maximum_messages as usize);
+
             // A vector of tuples which contain the length of some message content.
             // This message is contained within the 3rd cell of the row within the tuples.
             // Color and alignment of the username along with message text wrapping is done here.
             let all_messages = &app
                 .messages
                 .iter()
+                .rev()
                 .map(|m| m.to_row(&config.frontend, &message_chunk_width))
                 .collect::<Vec<(u16, Row)>>();
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -13,7 +13,7 @@ use tui::{
 
 use crate::{
     handlers::{config::CompleteConfig, data::Data},
-    utils::{app::App, event},
+    utils::{app::App, event, text::align_text},
 };
 
 pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<()> {
@@ -32,6 +32,14 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
         .format(config.frontend.date_format.as_str())
         .to_string()
         .len() as u16;
+
+    let username_column_title = align_text(
+        "Username",
+        &config.frontend.username_alignment,
+        &config.frontend.maximum_username_length,
+    );
+
+    let column_titles = vec!["Time", &username_column_title, "Message content"];
 
     let table_width = &[
         Constraint::Length(date_format_length),
@@ -86,7 +94,7 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
 
             let table = Table::new(all_rows)
                 .header(
-                    Row::new(vec!["Time", "User", "Message content"])
+                    Row::new(column_titles.to_owned())
                         .style(Style::default().fg(Color::Yellow))
                         .bottom_margin(1),
                 )

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -44,7 +44,7 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
     let table_width = &[
         Constraint::Length(date_format_length),
         Constraint::Length(config.frontend.maximum_username_length),
-        Constraint::Min(1),
+        Constraint::Percentage(100),
     ];
 
     loop {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -63,7 +63,7 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
             let all_messages = &app
                 .messages
                 .iter()
-                .map(|m| m.to_row(&config.frontend.palette, chunk_width))
+                .map(|m| m.to_row(&config.frontend, &chunk_width))
                 .collect::<Vec<(u16, Row)>>();
 
             let total_row_height: usize = all_messages.iter().map(|r| r.0 as usize).sum();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -28,24 +28,32 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
     let backend = TermionBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let date_format_length = Local::now()
-        .format(config.frontend.date_format.as_str())
-        .to_string()
-        .len() as u16;
-
     let username_column_title = align_text(
         "Username",
         &config.frontend.username_alignment,
         &config.frontend.maximum_username_length,
     );
 
-    let column_titles = vec!["Time", &username_column_title, "Message content"];
+    let mut column_titles = vec![username_column_title.as_str(), "Message content"];
 
-    let table_width = &[
-        Constraint::Length(date_format_length),
+    let mut table_width = vec![
         Constraint::Length(config.frontend.maximum_username_length),
         Constraint::Percentage(100),
     ];
+
+    if config.frontend.date_shown {
+        column_titles.insert(0, "Time");
+
+        table_width.insert(
+            0,
+            Constraint::Length(
+                Local::now()
+                    .format(config.frontend.date_format.as_str())
+                    .to_string()
+                    .len() as u16,
+            ),
+        );
+    }
 
     loop {
         if let Ok(info) = rx.try_recv() {
@@ -65,24 +73,32 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
                 .constraints(table_width.as_ref())
                 .split(f.size());
 
-            let chunk_height = vertical_chunks[0].height as usize - 4;
-            let chunk_width = horizontal_chunks[2].width as usize - 4;
+            // 0'th index because no matter what index is obtained, they're the same height.
+            let general_chunk_height = vertical_chunks[0].height as usize - 4;
 
+            // The chunk furthest to the right is the messages, that's the one we want.
+            let message_chunk_width = horizontal_chunks[table_width.len() - 1].width as usize - 4;
+
+            // A vector of tuples which contain the length of some message content.
+            // This message is contained within the 3rd cell of the row within the tuples.
+            // Color and alignment of the username along with message text wrapping is done here.
             let all_messages = &app
                 .messages
                 .iter()
-                .map(|m| m.to_row(&config.frontend, &chunk_width))
+                .map(|m| m.to_row(&config.frontend, &message_chunk_width))
                 .collect::<Vec<(u16, Row)>>();
 
             let total_row_height: usize = all_messages.iter().map(|r| r.0 as usize).sum();
 
             let mut all_rows = all_messages.iter().map(|r| r.1.clone()).collect::<Vec<_>>();
 
-            if total_row_height >= chunk_height {
+            // Accounting for not all heights of rows to be the same due to text wrapping,
+            // so extra space needs to be used in order to scroll correctly.
+            if total_row_height >= general_chunk_height {
                 let mut row_sum = 0;
                 let mut final_index = 0;
-                for (index, (row_height, _row)) in all_messages.iter().rev().enumerate() {
-                    if row_sum >= chunk_height {
+                for (index, (row_height, _)) in all_messages.iter().rev().enumerate() {
+                    if row_sum >= general_chunk_height {
                         final_index = index;
                         break;
                     }
@@ -101,9 +117,9 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
                 .block(
                     Block::default()
                         .borders(Borders::ALL)
-                        .title("[ Table of messages ]"),
+                        .title(format!("[ {}'s chat stream ]", &config.twitch.channel)),
                 )
-                .widths(table_width)
+                .widths(table_width.as_ref())
                 .column_spacing(1);
 
             f.render_widget(table, vertical_chunks[0]);

--- a/src/twitch.rs
+++ b/src/twitch.rs
@@ -34,7 +34,6 @@ pub async fn twitch_irc(config: &CompleteConfig, tx: &Sender<Data>) {
                     .to_string(),
                 user,
                 msg.to_string(),
-                false,
             )) {
                 println!("{}", e);
             }

--- a/src/twitch.rs
+++ b/src/twitch.rs
@@ -28,15 +28,14 @@ pub async fn twitch_irc(config: &CompleteConfig, tx: &Sender<Data>) {
                 Some(username) => username.to_string(),
                 None => "Undefined username".to_string(),
             };
-            if let Err(e) = tx.send(Data::new(
+            tx.send(Data::new(
                 Local::now()
                     .format(config.frontend.date_format.as_str())
                     .to_string(),
                 user,
                 msg.to_string(),
-            )) {
-                println!("{}", e);
-            }
+            ))
+            .unwrap();
         }
     }
 }

--- a/src/utils/app.rs
+++ b/src/utils/app.rs
@@ -1,17 +1,19 @@
+use std::collections::VecDeque;
+
 use crate::handlers::data::Data;
 
 pub struct App {
     /// Current value of the input box
     pub input: String,
     /// History of recorded messages (time, username, message)
-    pub messages: Vec<Data>,
+    pub messages: VecDeque<Data>,
 }
 
-impl Default for App {
-    fn default() -> App {
+impl App {
+    pub fn new(data_limit: usize) -> App {
         App {
             input: String::new(),
-            messages: Vec::new(),
+            messages: VecDeque::with_capacity(data_limit),
         }
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod app;
 pub(crate) mod event;
+pub(crate) mod text;

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,0 +1,18 @@
+pub fn align_text(text: &str, alignment: &str, maximum_length: &u16) -> String {
+    match alignment {
+        "left" => text.to_string(),
+        "right" => format!(
+            "{}{}",
+            " ".repeat((maximum_length - text.len() as u16) as usize),
+            text
+        ),
+        "center" => {
+            let side_spaces = " ".repeat(
+                ((maximum_length / 2) - (((text.len() / 2) as f32).floor() as u16)) as usize,
+            );
+
+            format!("{}{}{}", side_spaces, text, side_spaces)
+        }
+        _ => text.to_string(),
+    }
+}


### PR DESCRIPTION
- Limiting total messages by truncating in `VecDeque` and `config.terminal.maximum_messages`.
- Usernames can now be aligned to either `left` (default), `right`, or `center`. This is done through `config.frontend.username_alignment`.
- For people who want to be able to see only the username and message of a user, they can now remove the time/date column. Modifiable through `config.frontend.date_shown`,
- Bumped the `tui` crate to 0.16.0, a fix for `Constraints::Min(1)` not showing anything is done by `Constraints::Percentage(100)`.