### PR TITLE
A helpful popup window for keybinds.

### DIFF
--- a/default-config.toml
+++ b/default-config.toml
@@ -26,12 +26,11 @@ username_alignment = "right"
 # The color palette for the username column: pastel (default), vibrant, warm, cool.
 palette = "pastel"
 
+# Changing this currently doesn't do anything.
 [keybinds]
 # Chat table.
 chat = "c"
 # Keybinds table.
-keybinds = "?"
-# Users in chat.
-users = "u"
+help = "?"
 # Quit application (the ESC key will always be enabled).
 quit = "q"

--- a/default-config.toml
+++ b/default-config.toml
@@ -25,3 +25,13 @@ maximum_username_length = 26
 username_alignment = "right"
 # The color palette for the username column: pastel (default), vibrant, warm, cool.
 palette = "pastel"
+
+[keybinds]
+# Chat table.
+chat = "c"
+# Keybinds table.
+keybinds = "?"
+# Users in chat.
+users = "u"
+# Quit application (the ESC key will always be enabled).
+quit = "q"

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -63,11 +63,11 @@ pub struct FrontendConfig {
 #[derive(Deserialize, Clone)]
 pub struct KeybindsConfig {
     /// Chat table.
-    pub chat: char,
+    pub chat: String,
     /// Keybinds table.
-    pub keybinds: char,
+    pub keybinds: String,
     /// Users in chat.
-    pub users: char,
+    pub users: String,
     /// Quit application (the ESC key will always be enabled).
-    pub quit: char,
+    pub quit: String,
 }

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -23,6 +23,8 @@ pub struct CompleteConfig {
     pub terminal: TerminalConfig,
     /// How everything looks to the user.
     pub frontend: FrontendConfig,
+    /// All the keybinds on the keyboard.
+    pub keybinds: KeybindsConfig,
 }
 
 #[derive(Deserialize, Clone)]
@@ -56,4 +58,16 @@ pub struct FrontendConfig {
     /// The color palette
     #[serde(default)]
     pub palette: Palette,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct KeybindsConfig {
+    /// Chat table.
+    pub chat: char,
+    /// Keybinds table.
+    pub keybinds: char,
+    /// Users in chat.
+    pub users: char,
+    /// Quit application (the ESC key will always be enabled).
+    pub quit: char,
 }

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -65,9 +65,7 @@ pub struct KeybindsConfig {
     /// Chat table.
     pub chat: String,
     /// Keybinds table.
-    pub keybinds: String,
-    /// Users in chat.
-    pub users: String,
+    pub help: String,
     /// Quit application (the ESC key will always be enabled).
     pub quit: String,
 }

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -1,10 +1,11 @@
-use tui::style::{Color, Color::Rgb, Style};
-use tui::widgets::{Cell, Row};
+use tui::{
+    style::{Color, Color::Rgb, Style},
+    widgets::{Cell, Row},
+};
 
-use crate::utils::colors::WindowStyles;
 use crate::{
     handlers::config::{FrontendConfig, Palette},
-    utils::{colors::hsl_to_rgb, text::align_text},
+    utils::{colors::hsl_to_rgb, colors::WindowStyles, text::align_text},
 };
 
 #[derive(Debug, Clone)]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,2 +1,2 @@
-pub(crate) mod config;
-pub(crate) mod data;
+pub mod config;
+pub mod data;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use crate::utils::app::App;
 mod handlers;
 mod tui;
 mod twitch;
+mod ui;
 mod utils;
 
 const CONFIG_PATH: &str = "config.toml";

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use handlers::config::CompleteConfig;
 use crate::utils::app::App;
 
 mod handlers;
-mod tui;
+mod terminal;
 mod twitch;
 mod ui;
 mod utils;
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
             twitch::twitch_irc(&config, &tx);
         });
 
-        tui::tui(cloned_config, app, rx).unwrap();
+        terminal::ui_driver(cloned_config, app, rx).unwrap();
     } else {
         println!(
             "Error: configuration not found. Please create a config file at '{}', and see '{}' for an example configuration.",

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -76,7 +76,7 @@ pub fn ui_driver(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Re
             match input {
                 Key::Char('c') => app.state = State::Chat,
                 Key::Char('?') => app.state = State::KeybindHelp,
-                Key::Esc => break,
+                Key::Char('q') | Key::Esc => break,
                 _ => {}
             }
         }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -15,7 +15,7 @@ use crate::{
     },
 };
 
-pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<()> {
+pub fn ui_driver(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<()> {
     let events = event::Events::with_config(event::Config {
         exit_key: Key::Esc,
         tick_rate: Duration::from_millis(config.terminal.tick_delay),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5,9 +5,9 @@ use chrono::offset::Local;
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
 use tui::{backend::TermionBackend, layout::Constraint, Terminal};
 
-use crate::ui::{chat::draw_chat_ui, keybinds::draw_keybinds_ui};
 use crate::{
     handlers::{config::CompleteConfig, data::Data},
+    ui::{chat::draw_chat_ui, keybinds::draw_keybinds_ui},
     utils::{
         app::{App, State},
         event,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3,17 +3,16 @@ use std::{io, sync::mpsc::Receiver, time::Duration};
 use anyhow::Result;
 use chrono::offset::Local;
 use termion::{event::Key, input::MouseTerminal, raw::IntoRawMode, screen::AlternateScreen};
-use tui::{
-    backend::TermionBackend,
-    layout::{Constraint, Direction, Layout},
-    style::{Color, Style},
-    widgets::{Block, Borders, Row, Table},
-    Terminal,
-};
+use tui::{backend::TermionBackend, layout::Constraint, Terminal};
 
+use crate::ui::{chat::draw_chat_ui, keybinds::draw_keybinds_ui};
 use crate::{
     handlers::{config::CompleteConfig, data::Data},
-    utils::{app::App, event, text::align_text},
+    utils::{
+        app::{App, State},
+        event,
+        text::align_text,
+    },
 };
 
 pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<()> {
@@ -34,17 +33,20 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
         &config.frontend.maximum_username_length,
     );
 
-    let mut column_titles = vec![username_column_title.as_str(), "Message content"];
+    let mut column_titles = vec![
+        username_column_title.to_owned(),
+        "Message content".to_string(),
+    ];
 
-    let mut table_width = vec![
+    let mut table_constraints = vec![
         Constraint::Length(config.frontend.maximum_username_length),
         Constraint::Percentage(100),
     ];
 
     if config.frontend.date_shown {
-        column_titles.insert(0, "Time");
+        column_titles.insert(0, "Time".to_string());
 
-        table_width.insert(
+        table_constraints.insert(
             0,
             Constraint::Length(
                 Local::now()
@@ -55,84 +57,27 @@ pub fn tui(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Result<(
         );
     }
 
+    app.column_titles = Option::Some(column_titles);
+    app.table_constraints = Option::Some(table_constraints);
+
+    let chat_config = config.clone();
+
     loop {
         if let Ok(info) = rx.try_recv() {
             app.messages.push_front(info);
         }
 
-        terminal.draw(|f| {
-            let vertical_chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .margin(1)
-                .constraints([Constraint::Min(1)].as_ref())
-                .split(f.size());
-
-            let horizontal_chunks = Layout::default()
-                .direction(Direction::Horizontal)
-                .margin(1)
-                .constraints(table_width.as_ref())
-                .split(f.size());
-
-            // 0'th index because no matter what index is obtained, they're the same height.
-            let general_chunk_height = vertical_chunks[0].height as usize - 4;
-
-            // The chunk furthest to the right is the messages, that's the one we want.
-            let message_chunk_width = horizontal_chunks[table_width.len() - 1].width as usize - 4;
-
-            // Making sure that messages do have a limit and don't eat up all the RAM.
-            &app.messages
-                .truncate(config.terminal.maximum_messages as usize);
-
-            // A vector of tuples which contain the length of some message content.
-            // This message is contained within the 3rd cell of the row within the tuples.
-            // Color and alignment of the username along with message text wrapping is done here.
-            let all_messages = &app
-                .messages
-                .iter()
-                .rev()
-                .map(|m| m.to_row(&config.frontend, &message_chunk_width))
-                .collect::<Vec<(u16, Row)>>();
-
-            let total_row_height: usize = all_messages.iter().map(|r| r.0 as usize).sum();
-
-            let mut all_rows = all_messages.iter().map(|r| r.1.clone()).collect::<Vec<_>>();
-
-            // Accounting for not all heights of rows to be the same due to text wrapping,
-            // so extra space needs to be used in order to scroll correctly.
-            if total_row_height >= general_chunk_height {
-                let mut row_sum = 0;
-                let mut final_index = 0;
-                for (index, (row_height, _)) in all_messages.iter().rev().enumerate() {
-                    if row_sum >= general_chunk_height {
-                        final_index = index;
-                        break;
-                    }
-                    row_sum += *row_height as usize;
-                }
-
-                all_rows = all_rows[all_rows.len() - final_index..].to_owned();
-            }
-
-            let table = Table::new(all_rows)
-                .header(
-                    Row::new(column_titles.to_owned())
-                        .style(Style::default().fg(Color::Yellow))
-                        .bottom_margin(1),
-                )
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .title(format!("[ {}'s chat stream ]", &config.twitch.channel)),
-                )
-                .widths(table_width.as_ref())
-                .column_spacing(1);
-
-            f.render_widget(table, vertical_chunks[0]);
+        terminal.draw(|mut frame| match app.state {
+            State::Chat => draw_chat_ui(&mut frame, &mut app, chat_config.to_owned()).unwrap(),
+            State::KeybindHelp => draw_keybinds_ui(&mut frame, chat_config.to_owned()).unwrap(),
         })?;
 
         if let event::Event::Input(input) = events.next()? {
-            if let Key::Esc = input {
-                break;
+            match input {
+                Key::Char('c') => app.state = State::Chat,
+                Key::Char('?') => app.state = State::KeybindHelp,
+                Key::Esc => break,
+                _ => {}
             }
         }
     }

--- a/src/twitch.rs
+++ b/src/twitch.rs
@@ -34,6 +34,7 @@ pub async fn twitch_irc(config: &CompleteConfig, tx: &Sender<Data>) {
                     .to_string(),
                 user,
                 msg.to_string(),
+                false,
             ))
             .unwrap();
         }

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use tui::backend::Backend;
+use tui::terminal::Frame;
+use tui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    widgets::{Block, Borders, Row, Table},
+};
+
+use crate::handlers::config::CompleteConfig;
+use crate::utils::app::App;
+
+pub fn draw_chat_ui<T>(frame: &mut Frame<T>, app: &mut App, config: CompleteConfig) -> Result<()>
+where
+    T: Backend,
+{
+    let table_widths = app.table_constraints.as_ref().unwrap();
+
+    let vertical_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([Constraint::Min(1)].as_ref())
+        .split(frame.size());
+
+    let horizontal_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .margin(1)
+        .constraints(table_widths.as_ref())
+        .split(frame.size());
+
+    // 0'th index because no matter what index is obtained, they're the same height.
+    let general_chunk_height = vertical_chunks[0].height as usize - 4;
+
+    // The chunk furthest to the right is the messages, that's the one we want.
+    let message_chunk_width = horizontal_chunks[table_widths.len() - 1].width as usize - 4;
+
+    // Making sure that messages do have a limit and don't eat up all the RAM.
+    app.messages
+        .truncate(config.terminal.maximum_messages as usize);
+
+    // A vector of tuples which contain the length of some message content.
+    // This message is contained within the 3rd cell of the row within the tuples.
+    // Color and alignment of the username along with message text wrapping is done here.
+    let all_messages = &app
+        .messages
+        .iter()
+        .rev()
+        .map(|m| m.to_row(&config.frontend, &message_chunk_width))
+        .collect::<Vec<(u16, Row)>>();
+
+    let total_row_height: usize = all_messages.iter().map(|r| r.0 as usize).sum();
+
+    let mut all_rows = all_messages.iter().map(|r| r.1.clone()).collect::<Vec<_>>();
+
+    // Accounting for not all heights of rows to be the same due to text wrapping,
+    // so extra space needs to be used in order to scroll correctly.
+    if total_row_height >= general_chunk_height {
+        let mut row_sum = 0;
+        let mut final_index = 0;
+        for (index, (row_height, _)) in all_messages.iter().rev().enumerate() {
+            if row_sum >= general_chunk_height {
+                final_index = index;
+                break;
+            }
+            row_sum += *row_height as usize;
+        }
+
+        all_rows = all_rows[all_rows.len() - final_index..].to_owned();
+    }
+
+    let table = Table::new(all_rows)
+        .header(
+            Row::new(app.column_titles.as_ref().unwrap().to_owned())
+                .style(Style::default().fg(Color::Yellow)),
+        )
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!("[ {}'s chat stream ]", &config.twitch.channel)),
+        )
+        .widths(table_widths.as_ref())
+        .column_spacing(1);
+
+    frame.render_widget(table, vertical_chunks[0]);
+
+    Ok(())
+}

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -1,14 +1,15 @@
 use anyhow::Result;
-use tui::backend::Backend;
-use tui::terminal::Frame;
 use tui::{
+    backend::Backend,
     layout::{Constraint, Direction, Layout},
+    terminal::Frame,
     widgets::{Block, Borders, Row, Table},
 };
 
-use crate::handlers::config::CompleteConfig;
-use crate::utils::app::App;
-use crate::utils::colors::WindowStyles;
+use crate::{
+    handlers::config::CompleteConfig,
+    utils::{app::App, colors::WindowStyles},
+};
 
 pub fn draw_chat_ui<T>(frame: &mut Frame<T>, app: &mut App, config: CompleteConfig) -> Result<()>
 where

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -3,12 +3,12 @@ use tui::backend::Backend;
 use tui::terminal::Frame;
 use tui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Style},
     widgets::{Block, Borders, Row, Table},
 };
 
 use crate::handlers::config::CompleteConfig;
 use crate::utils::app::App;
+use crate::utils::colors::WindowStyles;
 
 pub fn draw_chat_ui<T>(frame: &mut Frame<T>, app: &mut App, config: CompleteConfig) -> Result<()>
 where
@@ -71,12 +71,13 @@ where
     let table = Table::new(all_rows)
         .header(
             Row::new(app.column_titles.as_ref().unwrap().to_owned())
-                .style(Style::default().fg(Color::Yellow)),
+                .style(WindowStyles::new(WindowStyles::ColumnTitle)),
         )
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(format!("[ {}'s chat stream ]", &config.twitch.channel)),
+                .title(format!("[ {}'s chat stream ]", &config.twitch.channel))
+                .style(WindowStyles::new(WindowStyles::BoarderName)),
         )
         .widths(table_widths.as_ref())
         .column_spacing(1);

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -8,7 +8,7 @@ use tui::{
 
 use crate::{
     handlers::config::CompleteConfig,
-    utils::{colors::WindowStyles, text::vector2_col_sums},
+    utils::{colors::WindowStyles, text::vector2_col_max},
 };
 
 pub fn draw_keybinds_ui<T>(frame: &mut Frame<T>, config: CompleteConfig) -> Result<()>
@@ -17,28 +17,25 @@ where
 {
     let vertical_chunks = Layout::default()
         .direction(Direction::Vertical)
-        .margin(10)
-        .constraints([Constraint::Min(1)].as_ref())
+        .margin(5)
+        .constraints([Constraint::Percentage(100)].as_ref())
         .split(frame.size());
 
     let mut keybinds = vec![
         vec!["Description", "Keybind"],
         vec!["Bring up the chat window", config.keybinds.chat.as_str()],
-        vec![
-            "Bring up the table for keybinds",
-            config.keybinds.keybinds.as_str(),
-        ],
+        vec!["Keybinds help", config.keybinds.keybinds.as_str()],
         vec!["See all the users in chat", config.keybinds.users.as_str()],
         vec!["Quit this application", config.keybinds.quit.as_str()],
     ];
 
-    let (maximum_description_width, maximum_keybind_width) = vector2_col_sums(keybinds.clone());
+    let (maximum_description_width, maximum_keybind_width) = vector2_col_max(keybinds.clone());
 
     let column_names = keybinds.remove(0);
 
     let table_widths = vec![
-        Constraint::Length(maximum_description_width.clone()),
-        Constraint::Length(maximum_keybind_width.clone()),
+        Constraint::Min(maximum_description_width.clone()),
+        Constraint::Min(maximum_keybind_width.clone()),
     ];
 
     let table = Table::new(
@@ -47,15 +44,11 @@ where
             .map(|k| Row::new(k.clone()))
             .collect::<Vec<Row>>(),
     )
+    .header(Row::new(column_names.clone()).style(WindowStyles::new(WindowStyles::ColumnTitle)))
     .block(Block::default().borders(Borders::ALL).title("[ Keybinds ]"))
-    .column_spacing(1)
-    .style(WindowStyles::new(WindowStyles::BoarderName))
-    .header(
-        Row::new(column_names.clone())
-            .style(WindowStyles::new(WindowStyles::ColumnTitle))
-            .bottom_margin(0),
-    )
-    .widths(&table_widths);
+    .widths(&table_widths)
+    .column_spacing(2)
+    .style(WindowStyles::new(WindowStyles::BoarderName));
 
     frame.render_widget(table, vertical_chunks[0]);
 

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -24,8 +24,7 @@ where
     let mut keybinds = vec![
         vec!["Description", "Keybind"],
         vec!["Bring up the chat window", config.keybinds.chat.as_str()],
-        vec!["Keybinds help", config.keybinds.keybinds.as_str()],
-        vec!["See all the users in chat", config.keybinds.users.as_str()],
+        vec!["Keybinds help", config.keybinds.help.as_str()],
         vec!["Quit this application", config.keybinds.quit.as_str()],
     ];
 

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -6,9 +6,10 @@ use tui::{
     widgets::{Block, Borders, Row, Table},
 };
 
-use crate::handlers::config::CompleteConfig;
-use crate::utils::colors::WindowStyles;
-use crate::utils::text::vector2_col_sums;
+use crate::{
+    handlers::config::CompleteConfig,
+    utils::{colors::WindowStyles, text::vector2_col_sums},
+};
 
 pub fn draw_keybinds_ui<T>(frame: &mut Frame<T>, config: CompleteConfig) -> Result<()>
 where

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use tui::backend::Backend;
+use tui::terminal::Frame;
+use tui::{
+    layout::{Constraint, Direction, Layout},
+    widgets::{Block, Borders, Row, Table},
+};
+
+use crate::handlers::config::CompleteConfig;
+
+pub fn draw_keybinds_ui<T>(frame: &mut Frame<T>, config: CompleteConfig) -> Result<()>
+where
+    T: Backend,
+{
+    let vertical_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(5)
+        .constraints([Constraint::Min(10)].as_ref())
+        .split(frame.size());
+
+    let keybinds = vec![
+        ("Bring up the chat window", config.keybinds.chat),
+        ("Bring up the table for keybinds", config.keybinds.keybinds),
+        ("See all the users in chat", config.keybinds.users),
+        ("Quit this application", config.keybinds.quit),
+    ];
+
+    let table = Table::new(vec![Row::new(vec![])])
+        .block(Block::default().borders(Borders::ALL).title("[ Keybinds ]"))
+        .column_spacing(1);
+
+    frame.render_widget(table, vertical_chunks[0]);
+
+    Ok(())
+}

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
-use tui::backend::Backend;
-use tui::terminal::Frame;
 use tui::{
+    backend::Backend,
     layout::{Constraint, Direction, Layout},
+    terminal::Frame,
     widgets::{Block, Borders, Row, Table},
 };
 
 use crate::handlers::config::CompleteConfig;
+use crate::utils::colors::WindowStyles;
+use crate::utils::text::vector2_col_sums;
 
 pub fn draw_keybinds_ui<T>(frame: &mut Frame<T>, config: CompleteConfig) -> Result<()>
 where
@@ -14,20 +16,45 @@ where
 {
     let vertical_chunks = Layout::default()
         .direction(Direction::Vertical)
-        .margin(5)
-        .constraints([Constraint::Min(10)].as_ref())
+        .margin(10)
+        .constraints([Constraint::Min(1)].as_ref())
         .split(frame.size());
 
-    let keybinds = vec![
-        ("Bring up the chat window", config.keybinds.chat),
-        ("Bring up the table for keybinds", config.keybinds.keybinds),
-        ("See all the users in chat", config.keybinds.users),
-        ("Quit this application", config.keybinds.quit),
+    let mut keybinds = vec![
+        vec!["Description", "Keybind"],
+        vec!["Bring up the chat window", config.keybinds.chat.as_str()],
+        vec![
+            "Bring up the table for keybinds",
+            config.keybinds.keybinds.as_str(),
+        ],
+        vec!["See all the users in chat", config.keybinds.users.as_str()],
+        vec!["Quit this application", config.keybinds.quit.as_str()],
     ];
 
-    let table = Table::new(vec![Row::new(vec![])])
-        .block(Block::default().borders(Borders::ALL).title("[ Keybinds ]"))
-        .column_spacing(1);
+    let (maximum_description_width, maximum_keybind_width) = vector2_col_sums(keybinds.clone());
+
+    let column_names = keybinds.remove(0);
+
+    let table_widths = vec![
+        Constraint::Length(maximum_description_width.clone()),
+        Constraint::Length(maximum_keybind_width.clone()),
+    ];
+
+    let table = Table::new(
+        keybinds
+            .iter()
+            .map(|k| Row::new(k.clone()))
+            .collect::<Vec<Row>>(),
+    )
+    .block(Block::default().borders(Borders::ALL).title("[ Keybinds ]"))
+    .column_spacing(1)
+    .style(WindowStyles::new(WindowStyles::BoarderName))
+    .header(
+        Row::new(column_names.clone())
+            .style(WindowStyles::new(WindowStyles::ColumnTitle))
+            .bottom_margin(0),
+    )
+    .widths(&table_widths);
 
     frame.render_widget(table, vertical_chunks[0]);
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,0 +1,2 @@
+pub mod chat;
+pub mod keybinds;

--- a/src/utils/app.rs
+++ b/src/utils/app.rs
@@ -1,12 +1,25 @@
 use std::collections::VecDeque;
 
+use tui::layout::Constraint;
+
 use crate::handlers::data::Data;
+
+pub enum State {
+    Chat,
+    KeybindHelp,
+}
 
 pub struct App {
     /// Current value of the input box
     pub input: String,
     /// History of recorded messages (time, username, message)
     pub messages: VecDeque<Data>,
+    /// Which window the terminal is currently showing
+    pub state: State,
+    /// The constraints that are set on the table
+    pub table_constraints: Option<Vec<Constraint>>,
+    /// The titles of the columns within the table of the terminal
+    pub column_titles: Option<Vec<String>>,
 }
 
 impl App {
@@ -14,6 +27,9 @@ impl App {
         App {
             input: String::new(),
             messages: VecDeque::with_capacity(data_limit),
+            state: State::Chat,
+            table_constraints: None,
+            column_titles: None,
         }
     }
 }

--- a/src/utils/colors.rs
+++ b/src/utils/colors.rs
@@ -1,0 +1,53 @@
+use tui::style::{Color, Modifier, Style};
+
+pub enum WindowStyles {
+    BoarderName,
+    ColumnTitle,
+    Chat,
+    SystemChat,
+}
+
+impl WindowStyles {
+    pub fn new(style_type: WindowStyles) -> Style {
+        let style = Style::default();
+
+        match style_type {
+            WindowStyles::BoarderName => style.fg(Color::White),
+            WindowStyles::ColumnTitle => style.fg(Color::LightCyan).add_modifier(Modifier::BOLD),
+            WindowStyles::Chat => style.fg(Color::White),
+            WindowStyles::SystemChat => style.fg(Color::Red).add_modifier(Modifier::BOLD),
+        }
+    }
+}
+
+// https://css-tricks.com/converting-color-spaces-in-javascript/#hsl-to-rgb
+pub fn hsl_to_rgb(hue: f64, saturation: f64, lightness: f64) -> [u8; 3] {
+    // Color intensity
+    let chroma = (1. - (2. * lightness - 1.).abs()) * saturation;
+
+    // Second largest component
+    let x = chroma * (1. - ((hue / 60.) % 2. - 1.).abs());
+
+    // Amount to match lightness
+    let m = lightness - chroma / 2.;
+
+    // Convert to rgb based on color wheel section
+    let (mut red, mut green, mut blue) = match hue.round() as i32 {
+        0..=60 => (chroma, x, 0.),
+        61..=120 => (x, chroma, 0.),
+        121..=180 => (0., chroma, x),
+        181..=240 => (0., x, chroma),
+        241..=300 => (x, 0., chroma),
+        301..=360 => (chroma, 0., x),
+        _ => {
+            panic!("Invalid hue!");
+        }
+    };
+
+    // Add amount to each channel to match lightness
+    red = (red + m) * 255.;
+    green = (green + m) * 255.;
+    blue = (blue + m) * 255.;
+
+    [red as u8, green as u8, blue as u8]
+}

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -9,8 +9,7 @@ use std::{
     time::Duration,
 };
 
-use termion::event::Key;
-use termion::input::TermRead;
+use termion::{event::Key, input::TermRead};
 
 pub enum Event<I> {
     Input(I),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,3 @@
-pub(crate) mod app;
-pub(crate) mod event;
-pub(crate) mod text;
+pub mod app;
+pub mod event;
+pub mod text;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod app;
+pub mod colors;
 pub mod event;
 pub mod text;

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -16,3 +16,10 @@ pub fn align_text(text: &str, alignment: &str, maximum_length: &u16) -> String {
         _ => text.to_string(),
     }
 }
+
+pub fn vector2_col_sums(vec2: Vec<Vec<&str>>) -> (u16, u16) {
+    let col0 = vec2.iter().map(|v| v[0].len()).sum::<usize>();
+    let col1 = vec2.iter().map(|v| v[1].len()).sum::<usize>();
+
+    (col0 as u16, col1 as u16)
+}

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -17,9 +17,40 @@ pub fn align_text(text: &str, alignment: &str, maximum_length: &u16) -> String {
     }
 }
 
-pub fn vector2_col_sums(vec2: Vec<Vec<&str>>) -> (u16, u16) {
-    let col0 = vec2.iter().map(|v| v[0].len()).sum::<usize>();
-    let col1 = vec2.iter().map(|v| v[1].len()).sum::<usize>();
+pub fn vector2_col_max<T>(vec2: Vec<Vec<T>>) -> (u16, u16)
+where
+    T: AsRef<str>,
+{
+    let col0 = vec2.iter().map(|v| v[0].as_ref().len()).max().unwrap();
+    let col1 = vec2.iter().map(|v| v[1].as_ref().len()).max().unwrap();
 
     (col0 as u16, col1 as u16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reference_string_vec2() {
+        let vec2 = vec![vec!["", "s"], vec!["longer string", "lll"]];
+
+        let (col0, col1) = vector2_col_max(vec2);
+
+        assert_eq!(col0, 13);
+        assert_eq!(col1, 3);
+    }
+
+    #[test]
+    fn test_string_vec2() {
+        let vec2 = vec![
+            vec!["".to_string(), "another".to_string()],
+            vec!["".to_string(), "the last string".to_string()],
+        ];
+
+        let (col0, col1) = vector2_col_max(vec2);
+
+        assert_eq!(col0, 0);
+        assert_eq!(col1, 15);
+    }
 }


### PR DESCRIPTION
- New config variables for setting keybinds.
- Ability to switch between windows (chat, keybind help).
- Both the `q` and `Esc` key work for exiting out completely.
- Enum `WindowStyles` added for default color schemes in windows and boarders.
- `hsl_to_rgb` function moved to `colors.rs`
- Added `system` boolean for `Data` structure so if system messages are implemented in the future, it's already set up.
- `tui.rs` renamed to `terminal.rs`, and `tui` function within that file has been renamed to `ui_driver`.
- Chat drawing and keybinds moved to their own files.
- Added function in `text.rs` to see maximum length of string in columns of 2d vector.
- Some unit tests.