### PR TITLE
Sending messages to Twitch chat from the terminal.

### DIFF
--- a/default-config.toml
+++ b/default-config.toml
@@ -25,6 +25,8 @@ maximum_username_length = 26
 username_alignment = "right"
 # The color palette for the username column: pastel (default), vibrant, warm, cool.
 palette = "pastel"
+# if you want to be able to send messages to Twitch chat from the terminal.
+input = false
 
 # Changing this currently doesn't do anything.
 [keybinds]

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -55,9 +55,11 @@ pub struct FrontendConfig {
     pub maximum_username_length: u16,
     /// Which side the username should be aligned to.
     pub username_alignment: String,
-    /// The color palette
+    /// The color palette.
     #[serde(default)]
     pub palette: Palette,
+    /// If input to Twitch chat is wanted as well.
+    pub input: bool,
 }
 
 #[derive(Deserialize, Clone)]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -68,13 +68,13 @@ pub fn ui_driver(config: CompleteConfig, mut app: App, rx: Receiver<Data>) -> Re
         }
 
         terminal.draw(|mut frame| match app.state {
-            State::Chat => draw_chat_ui(&mut frame, &mut app, chat_config.to_owned()).unwrap(),
+            State::Normal => draw_chat_ui(&mut frame, &mut app, chat_config.to_owned()).unwrap(),
             State::KeybindHelp => draw_keybinds_ui(&mut frame, chat_config.to_owned()).unwrap(),
         })?;
 
         if let event::Event::Input(input) = events.next()? {
             match input {
-                Key::Char('c') => app.state = State::Chat,
+                Key::Char('c') => app.state = State::Normal,
                 Key::Char('?') => app.state = State::KeybindHelp,
                 Key::Char('q') | Key::Esc => break,
                 _ => {}

--- a/src/twitch.rs
+++ b/src/twitch.rs
@@ -1,13 +1,17 @@
-use std::sync::mpsc::Sender;
-
 use chrono::offset::Local;
-use futures::prelude::*;
-use irc::client::prelude::*;
+use futures::{FutureExt, StreamExt};
+use irc::{
+    client::{data::Config, Client},
+    proto::Command,
+};
+use tokio::{
+    sync::mpsc::{Receiver, Sender},
+    task::unconstrained,
+};
 
 use crate::handlers::{config::CompleteConfig, data::Data};
 
-#[tokio::main]
-pub async fn twitch_irc(config: &CompleteConfig, tx: &Sender<Data>) {
+pub async fn twitch_irc(config: &CompleteConfig, tx: Sender<Data>, mut rx: Receiver<String>) {
     let irc_config = Config {
         nickname: Some(config.twitch.username.to_owned()),
         server: Some(config.twitch.server.to_owned()),
@@ -18,25 +22,34 @@ pub async fn twitch_irc(config: &CompleteConfig, tx: &Sender<Data>) {
         ..Default::default()
     };
 
-    let mut client = Client::from_config(irc_config).await.unwrap();
+    let mut client = Client::from_config(irc_config.clone()).await.unwrap();
     client.identify().unwrap();
     let mut stream = client.stream().unwrap();
 
-    while let Ok(Some(message)) = stream.next().await.transpose() {
-        if let Command::PRIVMSG(ref _target, ref msg) = message.command {
-            let user = match message.source_nickname() {
-                Some(username) => username.to_string(),
-                None => "Undefined username".to_string(),
-            };
-            tx.send(Data::new(
-                Local::now()
-                    .format(config.frontend.date_format.as_str())
-                    .to_string(),
-                user,
-                msg.to_string(),
-                false,
-            ))
-            .unwrap();
+    loop {
+        if let Some(Some(Ok(message))) = stream.next().now_or_never() {
+            if let Command::PRIVMSG(ref _target, ref msg) = message.command {
+                let user = match message.source_nickname() {
+                    Some(username) => username.to_string(),
+                    None => "Undefined username".to_string(),
+                };
+                tx.send(Data::new(
+                    Local::now()
+                        .format(config.frontend.date_format.as_str())
+                        .to_string(),
+                    user,
+                    msg.to_string(),
+                    false,
+                ))
+                .await
+                .unwrap();
+            }
+        }
+
+        if let Some(Some(message)) = unconstrained(rx.recv()).now_or_never() {
+            client
+                .send_privmsg(format!("#{}", config.twitch.channel), message)
+                .unwrap();
         }
     }
 }

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -17,10 +17,16 @@ where
 {
     let table_widths = app.table_constraints.as_ref().unwrap();
 
+    let mut vertical_chunk_constraints = vec![Constraint::Min(1)];
+
+    if config.frontend.input {
+        vertical_chunk_constraints.push(Constraint::Length(3));
+    }
+
     let vertical_chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(1)
-        .constraints([Constraint::Min(1)].as_ref())
+        .constraints(vertical_chunk_constraints.as_ref())
         .split(frame.size());
 
     let horizontal_chunks = Layout::default()

--- a/src/utils/app.rs
+++ b/src/utils/app.rs
@@ -11,12 +11,12 @@ pub enum State {
 }
 
 pub struct App {
-    /// Current value of the input box
-    pub input: String,
     /// History of recorded messages (time, username, message)
     pub messages: VecDeque<Data>,
     /// Which window the terminal is currently showing
     pub state: State,
+    /// Current value of the input box
+    pub input_text: String,
     /// The constraints that are set on the table
     pub table_constraints: Option<Vec<Constraint>>,
     /// The titles of the columns within the table of the terminal
@@ -26,9 +26,9 @@ pub struct App {
 impl App {
     pub fn new(data_limit: usize) -> App {
         App {
-            input: String::new(),
             messages: VecDeque::with_capacity(data_limit),
             state: State::Normal,
+            input_text: String::new(),
             table_constraints: None,
             column_titles: None,
         }

--- a/src/utils/app.rs
+++ b/src/utils/app.rs
@@ -5,8 +5,9 @@ use tui::layout::Constraint;
 use crate::handlers::data::Data;
 
 pub enum State {
-    Chat,
+    Normal,
     KeybindHelp,
+    Input,
 }
 
 pub struct App {
@@ -27,7 +28,7 @@ impl App {
         App {
             input: String::new(),
             messages: VecDeque::with_capacity(data_limit),
-            state: State::Chat,
+            state: State::Normal,
             table_constraints: None,
             column_titles: None,
         }

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -30,15 +30,6 @@ pub struct Config {
     pub tick_rate: Duration,
 }
 
-impl Default for Config {
-    fn default() -> Config {
-        Config {
-            exit_key: Key::Esc,
-            tick_rate: Duration::from_millis(250),
-        }
-    }
-}
-
 impl Events {
     pub fn with_config(config: Config) -> Events {
         let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
# Changes
- `Esc` can now back out of layered windows (ex. you're in the help window, and you want to go back to chat then exit. `Esc` can be hit to go back to chat, and then again to exit)
- Constraint added to allow space for user input.
- `input` is now a variable in `default-config.toml`, so the user can decide if they want the option to input messages to Twitch chat.