### PR TITLE
Popup insert mode at the bottom of the terminal

### DIFF
--- a/default-config.toml
+++ b/default-config.toml
@@ -25,8 +25,6 @@ maximum_username_length = 26
 username_alignment = "right"
 # The color palette for the username column: pastel (default), vibrant, warm, cool.
 palette = "pastel"
-# if you want to be able to send messages to Twitch chat from the terminal.
-input = false
 
 # Changing this currently doesn't do anything.
 [keybinds]

--- a/default-config.toml
+++ b/default-config.toml
@@ -25,12 +25,3 @@ maximum_username_length = 26
 username_alignment = "right"
 # The color palette for the username column: pastel (default), vibrant, warm, cool.
 palette = "pastel"
-
-# Changing this currently doesn't do anything.
-[keybinds]
-# Chat table.
-chat = "c"
-# Keybinds table.
-help = "?"
-# Quit application (the ESC key will always be enabled).
-quit = "q"

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -23,8 +23,6 @@ pub struct CompleteConfig {
     pub terminal: TerminalConfig,
     /// How everything looks to the user.
     pub frontend: FrontendConfig,
-    /// All the keybinds on the keyboard.
-    pub keybinds: KeybindsConfig,
 }
 
 #[derive(Deserialize, Clone)]
@@ -58,14 +56,4 @@ pub struct FrontendConfig {
     /// The color palette.
     #[serde(default)]
     pub palette: Palette,
-}
-
-#[derive(Deserialize, Clone)]
-pub struct KeybindsConfig {
-    /// Chat table.
-    pub chat: String,
-    /// Keybinds table.
-    pub help: String,
-    /// Quit application (the ESC key will always be enabled).
-    pub quit: String,
 }

--- a/src/handlers/config.rs
+++ b/src/handlers/config.rs
@@ -58,8 +58,6 @@ pub struct FrontendConfig {
     /// The color palette.
     #[serde(default)]
     pub palette: Palette,
-    /// If input to Twitch chat is wanted as well.
-    pub input: bool,
 }
 
 #[derive(Deserialize, Clone)]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -84,7 +84,7 @@ pub async fn ui_driver(
             State::Normal | State::Input => {
                 draw_chat_ui(&mut frame, &mut app, chat_config.to_owned()).unwrap()
             }
-            State::KeybindHelp => draw_keybinds_ui(&mut frame, chat_config.to_owned()).unwrap(),
+            State::KeybindHelp => draw_keybinds_ui(&mut frame).unwrap(),
         })?;
 
         if let Some(event::Event::Input(input_event)) = &events.next().await {
@@ -118,6 +118,7 @@ pub async fn ui_driver(
                     Key::Char('c') => app.state = State::Normal,
                     Key::Char('?') => app.state = State::KeybindHelp,
                     Key::Char('i') => app.state = State::Input,
+                    Key::Char('q') => break 'outer,
                     Key::Esc => match app.state {
                         State::Normal => break 'outer,
                         State::KeybindHelp | State::Input => app.state = State::Normal,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -117,11 +117,7 @@ pub async fn ui_driver(
                 _ => match input_event {
                     Key::Char('c') => app.state = State::Normal,
                     Key::Char('?') => app.state = State::KeybindHelp,
-                    Key::Char('i') => {
-                        if config.frontend.input {
-                            app.state = State::Input
-                        }
-                    }
+                    Key::Char('i') => app.state = State::Input,
                     Key::Esc => match app.state {
                         State::Normal => break 'outer,
                         State::KeybindHelp | State::Input => app.state = State::Normal,

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -13,8 +13,10 @@ use crate::{
     utils::{
         app::{App, State},
         colors::WindowStyles,
+        text::horizontal_text_scroll,
     },
 };
+use std::cmp::Ordering;
 
 pub fn draw_chat_ui<T>(frame: &mut Frame<T>, app: &mut App, config: CompleteConfig) -> Result<()>
 where
@@ -97,17 +99,31 @@ where
     frame.render_widget(table, vertical_chunks[0]);
 
     if let State::Input = app.state {
-        let paragraph = Paragraph::new(app.input_text.as_ref())
+        let mut input_text_render = app.input_text.clone();
+
+        let input_text_width = vertical_chunks[1].x + input_text_render.width() as u16;
+
+        let y = vertical_chunks[1].y + 1;
+
+        match input_text_width.cmp(&(vertical_chunks[1].width - 3)) {
+            Ordering::Greater => {
+                input_text_render = horizontal_text_scroll(
+                    input_text_render.as_str(),
+                    vertical_chunks[1].width as usize - 3,
+                );
+                frame.set_cursor(input_text_render.width() as u16 + 2, y);
+            }
+            Ordering::Less => frame.set_cursor(input_text_width + 1, y),
+            Ordering::Equal => {
+                frame.set_cursor(vertical_chunks[1].width - 2, y);
+            }
+        }
+
+        let paragraph = Paragraph::new(input_text_render.as_ref())
             .style(Style::default().fg(Color::Yellow))
             .block(Block::default().borders(Borders::ALL).title("[ Input ]"));
 
         frame.render_widget(paragraph, vertical_chunks[1]);
-
-        // Setting the cursor while in insert mode so it looks correct.
-        frame.set_cursor(
-            vertical_chunks[1].x + app.input_text.width() as u16 + 1,
-            vertical_chunks[1].y + 1,
-        )
     }
 
     Ok(())

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -24,7 +24,7 @@ where
 
     let mut vertical_chunk_constraints = vec![Constraint::Min(1)];
 
-    if config.frontend.input {
+    if let State::Input = app.state {
         vertical_chunk_constraints.push(Constraint::Length(3));
     }
 
@@ -96,23 +96,18 @@ where
 
     frame.render_widget(table, vertical_chunks[0]);
 
-    if config.frontend.input {
+    if let State::Input = app.state {
         let paragraph = Paragraph::new(app.input_text.as_ref())
-            .style(match app.state {
-                State::Input => Style::default().fg(Color::Yellow),
-                _ => Style::default(),
-            })
+            .style(Style::default().fg(Color::Yellow))
             .block(Block::default().borders(Borders::ALL).title("[ Input ]"));
 
         frame.render_widget(paragraph, vertical_chunks[1]);
 
         // Setting the cursor while in insert mode so it looks correct.
-        if let State::Input = app.state {
-            frame.set_cursor(
-                vertical_chunks[1].x + app.input_text.width() as u16 + 1,
-                vertical_chunks[1].y + 1,
-            )
-        }
+        frame.set_cursor(
+            vertical_chunks[1].x + app.input_text.width() as u16 + 1,
+            vertical_chunks[1].y + 1,
+        )
     }
 
     Ok(())

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -6,12 +6,9 @@ use tui::{
     widgets::{Block, Borders, Row, Table},
 };
 
-use crate::{
-    handlers::config::CompleteConfig,
-    utils::{colors::WindowStyles, text::vector2_col_max},
-};
+use crate::utils::{colors::WindowStyles, text::vector2_col_max};
 
-pub fn draw_keybinds_ui<T>(frame: &mut Frame<T>, config: CompleteConfig) -> Result<()>
+pub fn draw_keybinds_ui<T>(frame: &mut Frame<T>) -> Result<()>
 where
     T: Backend,
 {
@@ -23,9 +20,13 @@ where
 
     let mut keybinds = vec![
         vec!["Description", "Keybind"],
-        vec!["Bring up the chat window", config.keybinds.chat.as_str()],
-        vec!["Keybinds help", config.keybinds.help.as_str()],
-        vec!["Quit this application", config.keybinds.quit.as_str()],
+        vec!["Bring up the chat window", "c"],
+        vec!["Keybinds help (this window)", "?"],
+        vec![
+            "Exit out layer window/entire app when in normal mode",
+            "Esc",
+        ],
+        vec!["Quit this application", "q"],
     ];
 
     let (maximum_description_width, maximum_keybind_width) = vector2_col_max(keybinds.clone());

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -21,6 +21,10 @@ pub fn align_text(text: &str, alignment: &str, maximum_length: u16) -> String {
     }
 }
 
+pub fn horizontal_text_scroll(s: &str, max_length: usize) -> String {
+    s[s.len() - max_length..].to_string()
+}
+
 pub fn vector2_col_max<T>(vec2: Vec<Vec<T>>) -> (u16, u16)
 where
     T: AsRef<str>,


### PR DESCRIPTION
- Insert box is at the bottom of the terminal, no longer permanent. Off by default.
- Activate the insert box with `i`.
- Keybinds are hardcoded for now.
- Horizontal scrolling to the right and left when the text in the insert box is too large and/or shrinks from overflow.