### PR TITLE
Improve performance.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
             twitch::twitch_irc(&config, twitch_tx, twitch_rx).await;
         });
 
-        terminal::ui_driver(cloned_config, app, terminal_tx, terminal_rx)
+        terminal::ui_driver(&cloned_config, app, terminal_tx, terminal_rx)
             .await
             .unwrap();
         std::process::exit(0);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 pub async fn ui_driver(
-    config: CompleteConfig,
+    config: &CompleteConfig,
     mut app: App,
     tx: Sender<String>,
     mut rx: Receiver<Data>,
@@ -71,8 +71,6 @@ pub async fn ui_driver(
     app.column_titles = Option::Some(column_titles);
     app.table_constraints = Option::Some(table_constraints);
 
-    let chat_config = config.clone();
-
     terminal.clear().unwrap();
 
     'outer: loop {
@@ -81,9 +79,7 @@ pub async fn ui_driver(
         }
 
         terminal.draw(|mut frame| match app.state {
-            State::Normal | State::Input => {
-                draw_chat_ui(&mut frame, &mut app, chat_config.to_owned()).unwrap()
-            }
+            State::Normal | State::Input => draw_chat_ui(&mut frame, &mut app, config).unwrap(),
             State::KeybindHelp => draw_keybinds_ui(&mut frame).unwrap(),
         })?;
 

--- a/src/ui/keybinds.rs
+++ b/src/ui/keybinds.rs
@@ -29,26 +29,24 @@ where
         vec!["Quit this application", "q"],
     ];
 
-    let (maximum_description_width, maximum_keybind_width) = vector2_col_max(keybinds.clone());
+    let (maximum_description_width, maximum_keybind_width) = vector2_col_max(&keybinds);
 
     let column_names = keybinds.remove(0);
 
     let table_widths = vec![
-        Constraint::Min(maximum_description_width.clone()),
-        Constraint::Min(maximum_keybind_width.clone()),
+        Constraint::Min(maximum_description_width),
+        Constraint::Min(maximum_keybind_width),
     ];
 
-    let table = Table::new(
-        keybinds
-            .iter()
-            .map(|k| Row::new(k.clone()))
-            .collect::<Vec<Row>>(),
-    )
-    .header(Row::new(column_names.clone()).style(WindowStyles::new(WindowStyles::ColumnTitle)))
-    .block(Block::default().borders(Borders::ALL).title("[ Keybinds ]"))
-    .widths(&table_widths)
-    .column_spacing(2)
-    .style(WindowStyles::new(WindowStyles::BoarderName));
+    let table = Table::new(keybinds.iter().map(|k| Row::new(k.iter().copied())))
+        .header(
+            Row::new(column_names.iter().copied())
+                .style(WindowStyles::new(WindowStyles::ColumnTitle)),
+        )
+        .block(Block::default().borders(Borders::ALL).title("[ Keybinds ]"))
+        .widths(&table_widths)
+        .column_spacing(2)
+        .style(WindowStyles::new(WindowStyles::BoarderName));
 
     frame.render_widget(table, vertical_chunks[0]);
 

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -25,7 +25,7 @@ pub fn horizontal_text_scroll(s: &str, max_length: usize) -> String {
     s[s.len() - max_length..].to_string()
 }
 
-pub fn vector2_col_max<T>(vec2: Vec<Vec<T>>) -> (u16, u16)
+pub fn vector2_col_max<T>(vec2: &Vec<Vec<T>>) -> (u16, u16)
 where
     T: AsRef<str>,
 {
@@ -73,7 +73,7 @@ mod tests {
     fn test_reference_string_vec2() {
         let vec2 = vec![vec!["", "s"], vec!["longer string", "lll"]];
 
-        let (col0, col1) = vector2_col_max(vec2);
+        let (col0, col1) = vector2_col_max(&vec2);
 
         assert_eq!(col0, 13);
         assert_eq!(col1, 3);
@@ -86,7 +86,7 @@ mod tests {
             vec!["".to_string(), "the last string".to_string()],
         ];
 
-        let (col0, col1) = vector2_col_max(vec2);
+        let (col0, col1) = vector2_col_max(&vec2);
 
         assert_eq!(col0, 0);
         assert_eq!(col1, 15);


### PR DESCRIPTION
The message height handling loop is massively simplified to avoid multiple iterations of the message queue.
Additionally, few redundant clones were removed.

I still have yet to figure out why the CPU usage is so high on my machine. But these are baby steps in the right direction.