### PR TITLE
Improve performance, for real this time.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ async fn main() -> Result<()> {
 
         let app = App::new(config.terminal.maximum_messages as usize);
 
-        let (twitch_tx, terminal_rx) = mpsc::channel(1);
-        let (terminal_tx, twitch_rx) = mpsc::channel(1);
+        let (twitch_tx, terminal_rx) = mpsc::channel(100);
+        let (terminal_tx, twitch_rx) = mpsc::channel(100);
         let cloned_config = config.clone();
 
         tokio::task::spawn(async move {

--- a/src/twitch.rs
+++ b/src/twitch.rs
@@ -56,7 +56,7 @@ pub async fn twitch_irc(config: &CompleteConfig, tx: Sender<Data>, mut rx: Recei
                             Local::now()
                                 .format(config.frontend.date_format.as_str())
                                 .to_string(),
-                            "twitch".to_string(),
+                            "Twitch".to_string(),
                             format!("NOTICE: {}", msg),
                             true,
                         ))

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
 use crossterm::event::{self, Event as CEvent, KeyCode, KeyEvent};
-use futures::FutureExt;
-use tokio::{sync::mpsc, task::unconstrained, task::JoinHandle, time::Instant};
+use tokio::{sync::mpsc, task::JoinHandle, time::Instant};
 
 pub enum Event<I> {
     Input(I),
@@ -58,6 +57,6 @@ impl Events {
     }
 
     pub async fn next(&mut self) -> Option<Event<KeyEvent>> {
-        unconstrained(self.rx.recv()).now_or_never().and_then(|f| f)
+        self.rx.recv().await
     }
 }

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -24,7 +24,7 @@ pub struct Config {
 
 impl Events {
     pub async fn with_config(config: Config) -> Events {
-        let (tx, rx) = mpsc::channel(1);
+        let (tx, rx) = mpsc::channel(100);
 
         let input_handle = {
             let tx = tx.clone();


### PR DESCRIPTION
In particular, the PR decreases CPU usage of the release binary from 200% on my machine to 10%.

`main`:
![image](https://user-images.githubusercontent.com/41782385/135933605-d3bb943d-fa2b-4368-9486-99ca4c4dd5ab.png)

`performance`:
![image](https://user-images.githubusercontent.com/41782385/135933698-86be2b63-d350-4787-a93c-9ffaaf64dd00.png)

10% is still high, but this is yet another step in the right direction.