### PR TITLE
Improve Twitch visibility.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ dependencies = [
  "tokio",
  "toml",
  "tui",
+ "unicode-segmentation",
  "unicode-width",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bytes"
@@ -63,6 +63,17 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
+ "winapi",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4ea1881992efc993e4dc50a324cdbd03216e41bdc8385720ff47efc9bd2ca8"
+dependencies = [
+ "error-code",
+ "str-buf",
  "winapi",
 ]
 
@@ -133,10 +144,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -206,6 +238,33 @@ name = "encoding_index_tests"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "error-code"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5115567ac25674e0043e472be13d14e537f37ea8aa4bdc4aef0c89add1db1ff"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
+name = "fd-lock"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8806dd91a06a7a403a8e596f9bfbfb34e469efbc363fc9c9713e79e26472e36"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "foreign-types"
@@ -419,6 +478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +524,28 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3bb9a13fa32bc5aeb64150cd3f32d6cf4c748f8f8a417cce5d2eb976a8370ba"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -635,6 +725,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +820,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustyline"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790487c3881a63489ae77126f57048b42d62d3b2bafbf37453ea19eedb6340d6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "dirs-next",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "smallvec",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,9 +861,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.4.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -827,6 +951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
+name = "str-buf"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
+
+[[package]]
 name = "syn"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +992,7 @@ dependencies = [
  "futures",
  "irc",
  "rand",
+ "rustyline",
  "serde",
  "textwrap",
  "tokio",
@@ -1025,6 +1156,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ toml = "0.5.8"
 serde = { version = "1.0.130", features = ["derive"] }
 textwrap = "0.14.2"
 dirs = "4.0.0"
+rustyline = "9.0.0"
 
 [[bin]]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
 anyhow = "1.0.44"
 rand = "0.8.4"
 unicode-width = "0.1.9"
+unicode-segmentation = "1.8.0"
 chrono = "0.4"
 irc = "0.15.0"
 futures = "0.3.17"

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -28,6 +28,15 @@ impl<'conf> DataBuilder<'conf> {
         }
     }
 
+    pub fn system(self, message: String) -> Data {
+        Data {
+            time_sent: Local::now().format(self.date_format).to_string(),
+            author: "System".to_string(),
+            system: true,
+            message,
+        }
+    }
+
     pub fn twitch(self, message: String) -> Data {
         Data {
             time_sent: Local::now().format(self.date_format).to_string(),
@@ -111,12 +120,12 @@ mod tests {
     use super::*;
 
     fn create_data() -> Data {
-        Data::new(
-            Local::now().format("%c").to_string(),
-            "human".to_string(),
-            "beep boop".to_string(),
-            false,
-        )
+        Data {
+            time_sent: Local::now().format("%c").to_string(),
+            author: "human".to_string(),
+            message: "beep boop".to_string(),
+            system: false,
+        }
     }
 
     #[test]

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -1,3 +1,4 @@
+use chrono::offset::Local;
 use tui::{
     style::{Color, Color::Rgb, Style},
     widgets::{Cell, Row},
@@ -8,6 +9,35 @@ use crate::{
     utils::{colors::hsl_to_rgb, styles, text::align_text},
 };
 
+#[derive(Debug, Copy, Clone)]
+pub struct DataBuilder<'conf> {
+    pub date_format: &'conf str,
+}
+
+impl<'conf> DataBuilder<'conf> {
+    pub fn new(date_format: &'conf str) -> Self {
+        DataBuilder { date_format }
+    }
+
+    pub fn user(self, user: String, message: String) -> Data {
+        Data {
+            time_sent: Local::now().format(self.date_format).to_string(),
+            author: user,
+            system: false,
+            message,
+        }
+    }
+
+    pub fn twitch(self, message: String) -> Data {
+        Data {
+            time_sent: Local::now().format(self.date_format).to_string(),
+            author: "Twitch".to_string(),
+            system: true,
+            message,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Data {
     pub time_sent: String,
@@ -17,15 +47,6 @@ pub struct Data {
 }
 
 impl Data {
-    pub fn new(time_sent: String, author: String, message: String, system: bool) -> Self {
-        Data {
-            time_sent,
-            author,
-            message,
-            system,
-        }
-    }
-
     fn hash_username(&self, palette: &Palette) -> Color {
         let hash = self
             .author

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -15,7 +15,10 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tui::{backend::CrosstermBackend, layout::Constraint, Terminal};
 
 use crate::{
-    handlers::{config::CompleteConfig, data::Data},
+    handlers::{
+        config::CompleteConfig,
+        data::{Data, DataBuilder},
+    },
     ui::{chat::draw_chat_ui, keybinds::draw_keybinds_ui},
     utils::{
         self,
@@ -80,6 +83,8 @@ pub async fn ui_driver(
     app.table_constraints = Option::Some(table_constraints);
 
     terminal.clear().unwrap();
+
+    let data_builder = DataBuilder::new(&config.frontend.date_format);
 
     let quitting = |mut terminal: Terminal<CrosstermBackend<Stdout>>| {
         disable_raw_mode().unwrap();
@@ -149,13 +154,9 @@ pub async fn ui_driver(
                     }
                     Key::Enter => {
                         let input_message = app.input_text.as_str();
-                        app.messages.push_front(Data::new(
-                            Local::now()
-                                .format(config.frontend.date_format.as_str())
-                                .to_string(),
+                        app.messages.push_front(data_builder.user(
                             config.twitch.username.to_string(),
                             input_message.to_string(),
-                            false,
                         ));
 
                         tx.send(input_message.to_string()).await.unwrap();

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -84,27 +84,23 @@ where
     frame.render_widget(table, vertical_chunks[0]);
 
     if let State::Input = app.state {
-        let mut rendered_text = app.input_text.as_str();
+        let text = app.input_text.as_str();
+        let cursor_pos = app.input_text.pos();
+        let input_rect = vertical_chunks[1];
 
-        let input_text_width = vertical_chunks[1].x + rendered_text.width() as u16;
+        frame.set_cursor(
+            (input_rect.x + cursor_pos as u16 + 1)
+                .min(input_rect.x + input_rect.width.saturating_sub(2)),
+            input_rect.y + 1,
+        );
 
-        let y = vertical_chunks[1].y + 1;
-
-        match input_text_width.cmp(&(vertical_chunks[1].width - 3)) {
-            Ordering::Greater => {
-                rendered_text =
-                    &rendered_text[rendered_text.len() - vertical_chunks[1].width as usize - 3..];
-                frame.set_cursor(rendered_text.width() as u16 + 2, y);
-            }
-            Ordering::Less => frame.set_cursor(input_text_width + 1, y),
-            Ordering::Equal => {
-                frame.set_cursor(vertical_chunks[1].width - 2, y);
-            }
-        }
-
-        let paragraph = Paragraph::new(rendered_text)
+        let paragraph = Paragraph::new(text)
             .style(Style::default().fg(Color::Yellow))
-            .block(Block::default().borders(Borders::ALL).title("[ Input ]"));
+            .block(Block::default().borders(Borders::ALL).title("[ Input ]"))
+            .scroll((
+                0,
+                ((cursor_pos + 3) as u16).saturating_sub(input_rect.width),
+            ));
 
         frame.render_widget(paragraph, vertical_chunks[1]);
     }

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -1,5 +1,3 @@
-use std::cmp::Ordering;
-
 use anyhow::Result;
 use tui::{
     backend::Backend,
@@ -8,13 +6,13 @@ use tui::{
     terminal::Frame,
     widgets::{Block, Borders, Paragraph, Row, Table},
 };
-use unicode_width::UnicodeWidthStr;
 
 use crate::{
     handlers::config::CompleteConfig,
     utils::{
         app::{App, State},
         styles,
+        text::get_cursor_position,
     },
 };
 
@@ -85,7 +83,7 @@ where
 
     if let State::Input = app.state {
         let text = app.input_text.as_str();
-        let cursor_pos = app.input_text.pos();
+        let cursor_pos = get_cursor_position(&app.input_text);
         let input_rect = vertical_chunks[1];
 
         frame.set_cursor(

--- a/src/ui/chat.rs
+++ b/src/ui/chat.rs
@@ -15,7 +15,6 @@ use crate::{
     utils::{
         app::{App, State},
         styles,
-        text::horizontal_text_scroll,
     },
 };
 
@@ -85,19 +84,17 @@ where
     frame.render_widget(table, vertical_chunks[0]);
 
     if let State::Input = app.state {
-        let mut input_text_render = app.input_text.clone();
+        let mut rendered_text = app.input_text.as_str();
 
-        let input_text_width = vertical_chunks[1].x + input_text_render.width() as u16;
+        let input_text_width = vertical_chunks[1].x + rendered_text.width() as u16;
 
         let y = vertical_chunks[1].y + 1;
 
         match input_text_width.cmp(&(vertical_chunks[1].width - 3)) {
             Ordering::Greater => {
-                input_text_render = horizontal_text_scroll(
-                    input_text_render.as_str(),
-                    vertical_chunks[1].width as usize - 3,
-                );
-                frame.set_cursor(input_text_render.width() as u16 + 2, y);
+                rendered_text =
+                    &rendered_text[rendered_text.len() - vertical_chunks[1].width as usize - 3..];
+                frame.set_cursor(rendered_text.width() as u16 + 2, y);
             }
             Ordering::Less => frame.set_cursor(input_text_width + 1, y),
             Ordering::Equal => {
@@ -105,7 +102,7 @@ where
             }
         }
 
-        let paragraph = Paragraph::new(input_text_render.as_ref())
+        let paragraph = Paragraph::new(rendered_text)
             .style(Style::default().fg(Color::Yellow))
             .block(Block::default().borders(Borders::ALL).title("[ Input ]"));
 

--- a/src/utils/app.rs
+++ b/src/utils/app.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 
+use rustyline::line_buffer::LineBuffer;
 use tui::layout::Constraint;
 
 use crate::handlers::data::Data;
@@ -16,7 +17,7 @@ pub struct App {
     /// Which window the terminal is currently showing
     pub state: State,
     /// Current value of the input box
-    pub input_text: String,
+    pub input_text: LineBuffer,
     /// The constraints that are set on the table
     pub table_constraints: Option<Vec<Constraint>>,
     /// The titles of the columns within the table of the terminal
@@ -28,7 +29,7 @@ impl App {
         App {
             messages: VecDeque::with_capacity(data_limit),
             state: State::Normal,
-            input_text: String::new(),
+            input_text: LineBuffer::with_capacity(4096),
             table_constraints: None,
             column_titles: None,
         }

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -22,6 +22,7 @@ pub enum Key {
     Enter,
     Char(char),
     Ctrl(char),
+    Alt(char),
     F(u8),
     Null,
 }
@@ -78,10 +79,9 @@ impl Events {
                                 KeyCode::Null => Key::Null,
                                 KeyCode::F(k) => Key::F(k),
                                 KeyCode::Char(c) => match key.modifiers {
-                                    KeyModifiers::NONE
-                                    | KeyModifiers::SHIFT
-                                    | KeyModifiers::ALT => Key::Char(c),
+                                    KeyModifiers::NONE | KeyModifiers::SHIFT => Key::Char(c),
                                     KeyModifiers::CONTROL => Key::Ctrl(c),
+                                    KeyModifiers::ALT => Key::Alt(c),
                                     _ => Key::Null,
                                 },
                             };

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -1,7 +1,30 @@
 use std::time::Duration;
 
-use crossterm::event::{self, Event as CEvent, KeyCode, KeyEvent};
+use crossterm::event::{self, Event as CEvent, KeyCode, KeyModifiers};
 use tokio::{sync::mpsc, task::JoinHandle, time::Instant};
+
+#[derive(Debug, Clone, Copy)]
+pub enum Key {
+    Backspace,
+    Esc,
+    Up,
+    Down,
+    Left,
+    Right,
+    Home,
+    End,
+    Delete,
+    Insert,
+    PageUp,
+    PageDown,
+    Tab,
+    BackTab,
+    Enter,
+    Char(char),
+    Ctrl(char),
+    F(u8),
+    Null,
+}
 
 pub enum Event<I> {
     Input(I),
@@ -10,13 +33,13 @@ pub enum Event<I> {
 
 #[allow(dead_code)]
 pub struct Events {
-    rx: mpsc::Receiver<Event<KeyEvent>>,
+    rx: mpsc::Receiver<Event<Key>>,
     input_handle: JoinHandle<()>,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct Config {
-    pub exit_key: KeyCode,
+    pub exit_key: Key,
     pub tick_rate: Duration,
 }
 
@@ -36,6 +59,32 @@ impl Events {
 
                     if event::poll(timeout).unwrap() {
                         if let Ok(CEvent::Key(key)) = event::read() {
+                            let key = match key.code {
+                                KeyCode::Backspace => Key::Backspace,
+                                KeyCode::Esc => Key::Esc,
+                                KeyCode::Up => Key::Up,
+                                KeyCode::Down => Key::Down,
+                                KeyCode::Left => Key::Left,
+                                KeyCode::Right => Key::Right,
+                                KeyCode::Home => Key::Home,
+                                KeyCode::End => Key::End,
+                                KeyCode::Delete => Key::Delete,
+                                KeyCode::Insert => Key::Insert,
+                                KeyCode::PageUp => Key::PageUp,
+                                KeyCode::PageDown => Key::PageDown,
+                                KeyCode::Tab => Key::Tab,
+                                KeyCode::BackTab => Key::BackTab,
+                                KeyCode::Enter => Key::Enter,
+                                KeyCode::Null => Key::Null,
+                                KeyCode::F(k) => Key::F(k),
+                                KeyCode::Char(c) => match key.modifiers {
+                                    KeyModifiers::NONE
+                                    | KeyModifiers::SHIFT
+                                    | KeyModifiers::ALT => Key::Char(c),
+                                    KeyModifiers::CONTROL => Key::Ctrl(c),
+                                    _ => Key::Null,
+                                },
+                            };
                             if let Err(err) = tx.send(Event::Input(key)).await {
                                 eprintln!("{}", err);
                                 return;
@@ -56,7 +105,7 @@ impl Events {
         Events { rx, input_handle }
     }
 
-    pub async fn next(&mut self) -> Option<Event<KeyEvent>> {
+    pub async fn next(&mut self) -> Option<Event<Key>> {
         self.rx.recv().await
     }
 }

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,3 +1,7 @@
+use rustyline::line_buffer::LineBuffer;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
 pub fn align_text(text: &str, alignment: &str, maximum_length: u16) -> String {
     if maximum_length < 1 {
         panic!("Parameter of 'maximum_length' cannot be below 1.");
@@ -29,6 +33,15 @@ where
     let col1 = vec2.iter().map(|v| v[1].as_ref().len()).max().unwrap();
 
     (col0 as u16, col1 as u16)
+}
+
+pub fn get_cursor_position(line_buffer: &LineBuffer) -> usize {
+    line_buffer
+        .as_str()
+        .grapheme_indices(true)
+        .take_while(|(offset, _)| *offset != line_buffer.pos())
+        .map(|(_, cluster)| cluster.width())
+        .sum()
 }
 
 #[cfg(test)]

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -21,10 +21,6 @@ pub fn align_text(text: &str, alignment: &str, maximum_length: u16) -> String {
     }
 }
 
-pub fn horizontal_text_scroll(s: &str, max_length: usize) -> String {
-    s[s.len() - max_length..].to_string()
-}
-
 pub fn vector2_col_max<T>(vec2: &[Vec<T>]) -> (u16, u16)
 where
     T: AsRef<str>,


### PR DESCRIPTION
This PR improves the visibility of Twitch-specific commands by requesting the tags capability, which allows more metadata in commands sent by Twitch.

In particular, changes to room state like slowmode, subscribers-only are now shown in chat. Slash command feedback is also echoed to the chat window, which includes [everything here](https://help.twitch.tv/s/article/chat-commands?language=en_US). This somewhat implements @simonsan's moderation concerns.

![image](https://user-images.githubusercontent.com/41782385/136085832-db455581-2e6d-4719-a5a2-49a6b2d8a869.png)

Subscription/raid messages are also shown in the chat whenever received.

![image](https://user-images.githubusercontent.com/41782385/136090375-343a6c66-afcc-43fc-ba9e-c120b05a612e.png)

### git
Branch is created off #32, rebase and merge after that PR.